### PR TITLE
Fix *PACKAGE* bloating in DEFPACKAGE :EXPORT clause

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -1,13 +1,13 @@
 (defpackage #:sparql
   (:use #:cl #:parser-combinators)
-  (:export :sparql-query
-           :sparql-query*
-           :sparql
-           :sparql-compile
-           :sparql-eval
-           :enable-uri-syntax
-           :parse-literal
-           :render-literal
-           :make-uri
-           :define-uri-prefix
-           :get-uri-prefix))
+  (:export #:sparql-query
+           #:sparql-query*
+           #:sparql
+           #:sparql-compile
+           #:sparql-eval
+           #:enable-uri-syntax
+           #:parse-literal
+           #:render-literal
+           #:make-uri
+           #:define-uri-prefix
+           #:get-uri-prefix))


### PR DESCRIPTION
Replace `KEYWORD` in `DEFPACKAGE` `:EXPORT` clause with `UNINTERNED SYMBOL`. This avoids interning them in `*PACKAGE*`, therefore simplifying autocompletion and allowing garbage collection.